### PR TITLE
Add Go 1.16 to action workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.14', '1.15']
+        go: ['1.14', '1.15', '1.16']
     env:
       VERBOSE: 1
       GOFLAGS: -mod=readonly


### PR DESCRIPTION
Sneaking into the contributor's list with a simple CI change since the README instructions use `golang:1.16-alpine` as the Dockerfile builder. although `go.mod` specifies 1.15.