### PR TITLE
Report errors to client on `run` command

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,12 +68,14 @@ func main() {
 
 		err = preflight.ExecPiped(string(s), CLI.Run.Hash)
 		if err != nil {
+			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
 
 	case "run <hash|url> <cmd>":
 		err := preflight.Exec(CLI.Run.Cmd, CLI.Run.Hash)
 		if err != nil {
+			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
 

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 			os.Exit(1)
 		}
 		if !res.Ok {
-			preflight.Porcelain.CheckFailed(res)
+			preflight.Porcelain.ReportCheckResult(res)
 			os.Exit(1)
 		}
 		fmt.Print(content) // give back so piping can continue
@@ -114,7 +114,7 @@ func main() {
 		}
 
 		if !res.Ok {
-			preflight.Porcelain.CheckFailed(res)
+			preflight.Porcelain.ReportCheckResult(res)
 			os.Exit(1)
 		}
 
@@ -136,7 +136,7 @@ func main() {
 		}
 
 		if res.HasLookupVulns() {
-			preflight.Porcelain.CheckFailed(res)
+			preflight.Porcelain.ReportCheckResult(res)
 			os.Exit(1)
 		}
 
@@ -155,7 +155,7 @@ func main() {
 		res, err := preflight.Check(string(s), fmt.Sprintf("%v=?", CLI.Create.Digest))
 
 		if res.HasLookupVulns() {
-			preflight.Porcelain.CheckFailed(res)
+			preflight.Porcelain.ReportCheckResult(res)
 			os.Exit(1)
 		}
 

--- a/pkg/core.go
+++ b/pkg/core.go
@@ -201,7 +201,7 @@ func (a *Preflight) ExecPiped(script, sig string) error {
 		return err
 	}
 	if !check.Ok {
-		a.Porcelain.CheckFailed(check)
+		a.Porcelain.ReportCheckResult(check)
 		return nil
 	}
 	a.Porcelain.RunOk()
@@ -225,7 +225,7 @@ func (a *Preflight) Exec(args []string, sig string) error {
 	}
 
 	if !check.Ok {
-		a.Porcelain.CheckFailed(check)
+		a.Porcelain.ReportCheckResult(check)
 		return nil
 	}
 

--- a/pkg/core.go
+++ b/pkg/core.go
@@ -4,7 +4,6 @@ package pkg
 import (
 	//nolint
 	"crypto/md5"
-	"errors"
 	"net/http"
 
 	//nolint
@@ -68,20 +67,6 @@ type CheckResult struct {
 	ExpectedDigests []Signature
 	ActualDigest    Digest
 	Ok              bool
-}
-
-func (c *CheckResult) Error() error {
-	if c.Ok {
-		return nil
-	}
-
-	if c.HasLookupVulns() {
-		return fmt.Errorf("vulnerable digest: %v", c.ActualDigest)
-	} else if c.HasValidationVulns() {
-		return fmt.Errorf("digest mismatch: actual: %v, expected: %v", c.ActualDigest, c.ExpectedDigests)
-	} else {
-		return errors.New("unknown result error")
-	}
 }
 
 func (c *CheckResult) HasValidationVulns() bool {
@@ -217,7 +202,7 @@ func (a *Preflight) ExecPiped(script, sig string) error {
 	}
 	if !check.Ok {
 		a.Porcelain.CheckFailed(check)
-		return check.Error()
+		return nil
 	}
 	a.Porcelain.RunOk()
 
@@ -241,7 +226,7 @@ func (a *Preflight) Exec(args []string, sig string) error {
 
 	if !check.Ok {
 		a.Porcelain.CheckFailed(check)
-		return check.Error()
+		return nil
 	}
 
 	a.Porcelain.RunOk()

--- a/pkg/porcelain.go
+++ b/pkg/porcelain.go
@@ -44,7 +44,7 @@ func (p *Porcelain) RunOk() {
 }
 
 func (p *Porcelain) CheckFailed(check *CheckResult) {
-	if check.ValidDigest == nil {
+	if check.HasValidationVulns() {
 
 		green := color.New(color.FgGreen).SprintFunc()
 		red := color.New(color.FgRed).SprintFunc()
@@ -61,7 +61,7 @@ Actual:
 			green(fmtSigs(check.ExpectedDigests)),
 			red(check.ActualDigest.String()),
 		)
-	} else if check.LookupResult != nil && check.LookupResult.Vulnerable {
+	} else if check.HasLookupVulns() {
 		fmt.Printf(`%v Preflight failed:`, EMO_FAILED)
 		fmt.Printf(` Digest matches but marked as vulnerable.
 

--- a/pkg/porcelain.go
+++ b/pkg/porcelain.go
@@ -43,7 +43,7 @@ func (p *Porcelain) RunOk() {
 	fmt.Printf("%v Preflight verified\n", EMO_CHECK)
 }
 
-func (p *Porcelain) CheckFailed(check *CheckResult) {
+func (p *Porcelain) ReportCheckResult(check *CheckResult) {
 	if check.HasValidationVulns() {
 
 		green := color.New(color.FgGreen).SprintFunc()


### PR DESCRIPTION
In preflight commands there are 2 types of errors output:
1. Check failure errors (digest mismatch / vulnerable digest).
2. Processing errors / exceptions (bad hash source URL, bad hash set structure etc.).

Currently, the `run` command is not presenting error messages resulting from processing errors. If such an error has occurred the only display is `⌛️ Preflight starting` and the program exits. The rest of the commands do present error messages.
The check failure errors are displaying well.

`run` command Output example after processing error:
<img width="1041" alt="image" src="https://user-images.githubusercontent.com/44297242/198851972-2b41c67b-d7f5-48a6-9fb3-a7719e90bbdf.png">

The same output for the same input to `check` command:
<img width="1064" alt="image" src="https://user-images.githubusercontent.com/44297242/198852015-710dcff7-aa1f-4fad-aada-41e7f55a6ce7.png">

I think that the reason that errors are not presented is because during `run` command if the check has failed, both `a.Porcelain.CheckFailed(check)` and `check.Error()` are being called:
1. **`a.Porcelain.CheckFailed(check)`** - prints a friendly message with the failure reason and details.
2. **`check.Error()`** - creates an exception with an error message which being returned to `main.go` from `Exec` & `ExecPiped` methods.

`main.go` not prints the any error message (both check failure & processing errors) returned from `Exec` & `ExecPiped` methods probably in order to prevent a duplicate reporting of a check failure message, and therefore processing error message are not being reported as well.

**My suggestion is:** 
1. Remove `check.Error()` completely since the errors returned from this function have no effect and already friendly reported by `a.Porcelain.CheckFailed(check)`.
2. In `main.go` - if an error returned - print the error message (errors can be bad hash source URL, bad hash set structure etc.).
6. In case the check has failed (digest mismatch / vulnerable digest) in `run` command - return nil to not print the check failure message because `a.Porcelain.CheckFailed(check)` already reported a friendly message of the check failure.

This way we are creating a separation between reporting of check failures by `CheckFailed` method, and reporting of processing errors by `main.go` as all other commands does.

`run` command output with an error after this change:
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/44297242/198852791-b51ba1b7-8a7b-494d-880a-96ce8e5e2f9c.png">

Let me know your thoughts 😄 
